### PR TITLE
Fixes label for phpMyAdmin in portsAttributes

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,13 +3,13 @@
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "app",
 	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
-
+	
 	// Features to add to the dev container. More info: https://containers.dev/implementors/features.
 	"features": {
 	},
 
 	"customizations": {
-		"vscode": {		
+		"vscode": {
 			"extensions": [
 				"xdebug.php-pack",
 				"yogensia.searchwpdocs",
@@ -32,7 +32,7 @@
 	],
 
 	"postCreateCommand": "./.devcontainer/postCreateCommand.sh > .devcontainer/postCreateCommand.log  && code - r wordpress/wp-content/plugins/wp-codespace/wp-codespace.php",
-	
+
 	"portsAttributes": {
 		"3306": {
 			"label": "Database (internal)"
@@ -41,7 +41,7 @@
 			"label": "WordPress"
 		},
 		"81": {
-			"label": "phpMyAmdin"
+			"label": "phpMyAdmin"
 		}
 	},
 	"postStartCommand": "service apache2 start"


### PR DESCRIPTION
I bumped into a typo in .devcontainer/devcontainer.json while testing this out.
This PR fixes that typo.
I used GH code editor to edit this file and it introduced some white-space weirdness...I thought I got it all, but seems like I didn't.