### PR TITLE
Enabling of mod_rewrite

### DIFF
--- a/.devcontainer/000-default.conf
+++ b/.devcontainer/000-default.conf
@@ -4,6 +4,7 @@
 	DocumentRoot /workspaces/wp-codespace/wordpress
 
 	<Directory />
+		AllowOverride All
   	Require all granted
 	</Directory>
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/php:0-7.4
+FROM mcr.microsoft.com/devcontainers/php:0-8.3
 
 # Install MariaDB client
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
@@ -10,7 +10,7 @@ RUN docker-php-ext-install mysqli pdo pdo_mysql
 RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar && chmod +x wp-cli.phar && mv wp-cli.phar /usr/local/bin/wp
 
 # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
-ARG NODE_VERSION="19"
+ARG NODE_VERSION="21"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 
 # [Optional] Uncomment this section to install additional OS packages.


### PR DESCRIPTION
As currently configured, all links on wordpress pages fail, because Apache is not respecting the .htaccess file. Now, apache2 override set to all to allow htaccess through.

Also updated to php8 and npm 21.